### PR TITLE
Set correct side_key in public mode

### DIFF
--- a/out/src/node.js
+++ b/out/src/node.js
@@ -105,7 +105,7 @@ var getMamAddress = function (KEY, ROOT) {
     return ctrits_trits_to_string(address);
 };
 var createMessage = function (SEED, MESSAGE, SIDE_KEY, CHANNEL) {
-    if (!SIDE_KEY)
+    if (!SIDE_KEY || CHANNEL.mode === "public")
         SIDE_KEY = '999999999999999999999999999999999999999999999999999999999999999999999999999999999';
     // MAM settings
     var SEED_trits = string_to_ctrits_trits(SEED);

--- a/src/node.ts
+++ b/src/node.ts
@@ -151,7 +151,7 @@ const getMamAddress = (KEY, ROOT) => {
 }
 
 const createMessage = (SEED, MESSAGE, SIDE_KEY, CHANNEL) => {
-    if (!SIDE_KEY)
+    if (!SIDE_KEY || CHANNEL.mode === "public")
         SIDE_KEY = '999999999999999999999999999999999999999999999999999999999999999999999999999999999'
 
     // MAM settings


### PR DESCRIPTION
Hi 
i made sure that the correct side_key is used when public mode is used. 

The reason i did it was that i ran into the problem that i mistakenly set a side_key at MamWriter construction and using public mode. Therefore this side_key was used for encryption. 
This fix checks if mode is public and then ignores the side_key the user set. 